### PR TITLE
Fix stake amounts in transactions history

### DIFF
--- a/src/wallet/api/pending_transaction.cpp
+++ b/src/wallet/api/pending_transaction.cpp
@@ -165,10 +165,20 @@ bool PendingTransactionImpl::commit(const std::string &filename, bool overwrite)
 uint64_t PendingTransactionImpl::amount() const
 {
     uint64_t result = 0;
-    for (const auto &ptx : m_pending_tx)   {
-        for (const auto &dest : ptx.dests) {
-            result += dest.amount;
+    for (const auto &ptx : m_pending_tx) {
+        const auto txType = ptx.tx.type;
+        const bool isNotStandardTransfer =
+            txType == cryptonote::transaction_type::STAKE ||
+            txType == cryptonote::transaction_type::BURN  ||
+            txType == cryptonote::transaction_type::AUDIT;
+
+        if (isNotStandardTransfer && ptx.tx.amount_burnt > 0) {
+            result += ptx.tx.amount_burnt;
+            continue;
         }
+
+        for (const auto &dest : ptx.dests)
+            result += dest.amount;
     }
     return result;
 }


### PR DESCRIPTION
Currently salvium wallet api code incorrectly report stake tx amounts.
Stake amount is empty and actuall amount is shown as fee.
This pr fixes that issue.
It was tested on legacy gui to properly show staked amounts.
Same bug exists in Stack wallet. Possibly it will fix it as well.