### PR TITLE
Fix return outputs being dropped on a view-tag collision

### DIFF
--- a/src/carrot_core/output_set_finalization.cpp
+++ b/src/carrot_core/output_set_finalization.cpp
@@ -168,6 +168,7 @@ void get_output_enote_proposals(const std::vector<CarrotPaymentProposalV1> &norm
 {
     output_enote_proposals_out.clear();
     encrypted_payment_id_out = {{0}};
+    change_index_out = static_cast<size_t>(-1); // sentinel if no change output
     if (payment_proposal_order_out)
         payment_proposal_order_out->clear();
 

--- a/src/carrot_core/scan.cpp
+++ b/src/carrot_core/scan.cpp
@@ -115,7 +115,7 @@ bool scan_return_output(
             return_view_tag
         ),
         false,
-        "view tag verification failed for carrot coinbase enote"
+        "view tag verification failed for carrot return enote"
     );
 
     // 5. compute anchor_return
@@ -145,7 +145,7 @@ bool scan_return_output(
     CHECK_AND_ASSERT_MES(
         memcmp(recovered_ephemeral_pubkey_return.data, return_ephemeral_pubkey.data, sizeof(mx25519_pubkey)) == 0,
         false,
-        "carrot coinbase enote protection verification failed"
+        "carrot return enote protection verification failed"
     );
 
     amount_out = carrot::decrypt_carrot_amount(return_amount_enc, shared_secret_return, return_onetime_address);
@@ -488,15 +488,16 @@ bool try_scan_carrot_enote_internal_receiver(const CarrotEnoteV1 &enote,
     view_tag_t nominal_view_tag;
     account.s_view_balance_dev.make_internal_view_tag(input_context, enote.onetime_address, nominal_view_tag);
 
-    // test view tag
+    // view tag is only a probabilistic filter, so a failed internal scan must still fall
+    // through to the return-output check below
     if (nominal_view_tag == enote.view_tag) {
         // s^ctx_sr = H_32(s_vb, D_e, input_context)
         crypto::hash s_sender_receiver;
         account.s_view_balance_dev.make_internal_sender_receiver_secret(enote.enote_ephemeral_pubkey,
             input_context,
             s_sender_receiver);
-    
-        if (!try_scan_carrot_enote_internal_burnt(enote,
+
+        if (try_scan_carrot_enote_internal_burnt(enote,
             s_sender_receiver,
             sender_extension_g_out,
             sender_extension_t_out,
@@ -505,41 +506,37 @@ bool try_scan_carrot_enote_internal_receiver(const CarrotEnoteV1 &enote,
             amount_blinding_factor_out,
             enote_type_out,
             internal_message_out))
-            return false;
+        {
+            // we received a change output
+            // save the Kr = K_change + K_return to out subaddress map
+            for (const auto &output_key : enote.tx_output_keys) {
+                // make k_return
+                crypto::secret_key k_return;
+                const carrot::input_context_t input_context = carrot::make_carrot_input_context(enote.tx_first_key_image);
+                account.s_view_balance_dev.make_internal_return_privkey(input_context, output_key, k_return);
 
-        // we received a change output
-        // save the Kr = K_change + K_return to out subaddress map
-        for (const auto &output_key : enote.tx_output_keys) {
-            // make k_return
-            crypto::secret_key k_return;
-            const carrot::input_context_t input_context = carrot::make_carrot_input_context(enote.tx_first_key_image);
-            account.s_view_balance_dev.make_internal_return_privkey(input_context, output_key, k_return);
+                // compute K_return = k_return * G
+                crypto::public_key K_return;
+                crypto::secret_key_to_public_key(k_return, K_return);
 
-            // compute K_return = k_return * G
-            crypto::public_key K_return;
-            crypto::secret_key_to_public_key(k_return, K_return);
+                // compute K_r = K_return + K_o
+                crypto::public_key K_r = rct::rct2pk(rct::addKeys(rct::pk2rct(K_return), rct::pk2rct(enote.onetime_address)));
 
-            // compute K_r = K_return + K_o
-            crypto::public_key K_r = rct::rct2pk(rct::addKeys(rct::pk2rct(K_return), rct::pk2rct(enote.onetime_address)));
+                // calculate the key image for the return output
+                crypto::secret_key sum_g;
+                sc_add(to_bytes(sum_g), to_bytes(sender_extension_g_out), to_bytes(k_return));
+                crypto::key_image key_image = account.derive_key_image_view_only(address_spend_pubkey_out,
+                                                                                sum_g,
+                                                                                sender_extension_t_out,
+                                                                                K_r
+                                                                                );
 
-            // calculate the key image for the return output
-            crypto::secret_key sum_g;
-            sc_add(to_bytes(sum_g), to_bytes(sender_extension_g_out), to_bytes(k_return));
-            crypto::key_image key_image = account.derive_key_image_view_only(address_spend_pubkey_out,
-                                                                            sum_g,
-                                                                            sender_extension_t_out,
-                                                                            K_r
-                                                                            );
+                account.insert_return_output_info({{K_r, {input_context, output_key, enote.onetime_address, address_spend_pubkey_out, key_image, sum_g, sender_extension_t_out}}});
+            }
 
-            // HERE BE DRAGONS!!!
-            // SRCG: test whether this will even work for return_payment detection
-            account.insert_return_output_info({{K_r, {input_context, output_key, enote.onetime_address, address_spend_pubkey_out, key_image, sum_g, sender_extension_t_out}}});
-            //account.insert_return_output_info({{K_r, {input_context, output_key, address_spend_pubkey_out, key_image, sum_g, sender_extension_t_out}}});
-            // LAND AHOY!!!
+            // janus protection checks are not needed for internal scans
+            return true;
         }
-
-        // janus protection checks are not needed for internal scans
-        return true;
     }
 
     // check for known return addresses

--- a/src/wallet/tx_builder.cpp
+++ b/src/wallet/tx_builder.cpp
@@ -1215,7 +1215,7 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
     LOG_PRINT_L3("Getting output enote proposals");
     std::vector<carrot::RCTOutputEnoteProposal> output_enote_proposals;
     carrot::encrypted_payment_id_t encrypted_payment_id;
-    size_t change_index;
+    size_t change_index = static_cast<size_t>(-1); // sentinel if no change output
     carrot::RCTOutputEnoteProposal return_enote_out;
     std::unordered_map<crypto::public_key, size_t> payments_indices;
     carrot::get_output_enote_proposals(tx_proposal.normal_payment_proposals,
@@ -1368,6 +1368,10 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
             change_address_spend_pubkey = p.destination_address_spend_pubkey;
         }
     }
+    // need exactly one change output here; bail instead of indexing with the sentinel
+    THROW_WALLET_EXCEPTION_IF(change_index >= output_enote_proposals.size()
+            || change_address_spend_pubkey == crypto::public_key{},
+        error::wallet_internal_error, "carrot tx build: no change output in proposal");
     const carrot::RCTOutputEnoteProposal &change_enote_proposal = output_enote_proposals.at(change_index);
     const carrot::input_context_t input_context = carrot::make_carrot_input_context(tx_proposal.key_images_sorted.at(0));
     crypto::hash s_sender_receiver;

--- a/tests/unit_tests/carrot_return_index.cpp
+++ b/tests/unit_tests/carrot_return_index.cpp
@@ -27,8 +27,11 @@
 
 #include "gtest/gtest.h"
 
+#include "carrot_core/account.h"
 #include "carrot_core/account_secrets.h"
 #include "carrot_core/address_utils.h"
+#include "carrot_core/carrot_enote_types.h"
+#include "carrot_core/core_types.h"
 #include "carrot_core/enote_utils.h"
 #include "carrot_core/output_set_finalization.h"
 #include "carrot_core/payment_proposal.h"
@@ -36,6 +39,8 @@
 #include "crypto/crypto.h"
 #include "crypto/generators.h"
 #include "ringct/rctOps.h"
+
+#include <cstring>
 
 #include "carrot_mock_helpers.h"
 
@@ -169,4 +174,174 @@ TEST(carrot_return_index, payment_channel_multiple_returns)
 
     // Final verification: Alice's total matches Bob's total
     EXPECT_EQ(alice_total_received, bob_total_sent);
+}
+
+// a valid (non-colliding) return output is recovered through the return-map path, with the right
+// amount. guards the fall-through change in try_scan_carrot_enote_internal_receiver.
+TEST(carrot_return_index, return_output_detected)
+{
+    carrot::carrot_and_legacy_account recipient;
+    recipient.generate();
+
+    const crypto::key_image origin_ki = rct::rct2ki(rct::pkGen());
+    const input_context_t origin_input_context = make_carrot_input_context(origin_ki);
+    const crypto::public_key K_o = rct::rct2pk(rct::pkGen());
+    const crypto::public_key K_change = rct::rct2pk(rct::pkGen());
+
+    crypto::secret_key k_return;
+    recipient.s_view_balance_dev.make_internal_return_privkey(origin_input_context, K_o, k_return);
+    crypto::public_key K_return;
+    crypto::secret_key_to_public_key(k_return, K_return);
+
+    const crypto::key_image return_ki = rct::rct2ki(rct::pkGen());
+    const input_context_t return_input_context = make_carrot_input_context(return_ki);
+
+    const janus_anchor_t anchor = gen_janus_anchor();
+    crypto::secret_key d_e;
+    make_carrot_enote_ephemeral_privkey(anchor, return_input_context, K_change, null_payment_id, d_e);
+    mx25519_pubkey D_e;
+    make_carrot_enote_ephemeral_pubkey(d_e, K_change, /*is_subaddress=*/false, D_e);
+    mx25519_pubkey s_unctx;
+    ASSERT_TRUE(make_carrot_uncontextualized_shared_key_sender(d_e, K_return, s_unctx));
+    crypto::hash s_sr;
+    make_carrot_sender_receiver_secret(s_unctx.data, D_e, return_input_context, s_sr);
+
+    // real return address K_r = K_return + K_change
+    const crypto::public_key K_r = rct::rct2pk(rct::addKeys(rct::pk2rct(K_return), rct::pk2rct(K_change)));
+
+    const rct::xmr_amount amount = 1337;
+    crypto::secret_key k_a;
+    make_carrot_amount_blinding_factor(s_sr, amount, K_change, carrot::CarrotEnoteType::PAYMENT, k_a);
+
+    carrot::CarrotEnoteV1 enote{};
+    enote.onetime_address = K_r;
+    enote.amount_commitment = rct::commit(amount, rct::sk2rct(k_a));
+    enote.amount_enc = encrypt_carrot_amount(amount, s_sr, K_r);
+    enote.anchor_enc = encrypt_carrot_anchor(anchor, s_sr, K_r);
+    make_carrot_view_tag(s_unctx.data, return_input_context, K_r, enote.view_tag);
+    enote.enote_ephemeral_pubkey = D_e;
+    enote.tx_first_key_image = return_ki;
+    enote.asset_type = "SAL1";
+
+    recipient.insert_return_output_info({{K_r, carrot::return_output_info_t(
+        origin_input_context, K_o, K_change, K_change,
+        crypto::key_image{}, crypto::secret_key{}, crypto::secret_key{})}});
+
+    crypto::secret_key ext_g, ext_t, abf;
+    crypto::public_key spend_pubkey, return_address;
+    rct::xmr_amount scanned_amount = 0;
+    carrot::CarrotEnoteType etype;
+    janus_anchor_t internal_msg;
+    bool is_return = false;
+    const bool r = carrot::try_scan_carrot_enote_internal_receiver(enote, recipient,
+        ext_g, ext_t, spend_pubkey, scanned_amount, abf, etype, internal_msg,
+        return_address, is_return);
+
+    ASSERT_TRUE(r);
+    EXPECT_TRUE(is_return);
+    EXPECT_EQ(amount, scanned_amount);
+    EXPECT_EQ(K_change, spend_pubkey);
+    EXPECT_EQ(K_r, return_address);
+}
+
+// forces a real 24-bit view-tag collision so scanning enters the internal branch, fails it, and
+// must still fall through to the return map. brute-forces ~2^24 candidates (a few minutes), so
+// disabled by default; run with --gtest_also_run_disabled_tests. fails pre-fix, passes with the fix.
+TEST(carrot_return_index, DISABLED_view_tag_collision_return_still_detected)
+{
+    carrot::carrot_and_legacy_account recipient;
+    recipient.generate();
+
+    // origin tx whose change we own (what populates the return map in production)
+    const crypto::key_image origin_ki = rct::rct2ki(rct::pkGen());
+    const input_context_t origin_input_context = make_carrot_input_context(origin_ki);
+    const crypto::public_key K_o = rct::rct2pk(rct::pkGen());      // an origin output key
+    const crypto::public_key K_change = rct::rct2pk(rct::pkGen()); // our change onetime address
+
+    // k_return for this origin output, K_return = k_return G
+    crypto::secret_key k_return;
+    recipient.s_view_balance_dev.make_internal_return_privkey(origin_input_context, K_o, k_return);
+    crypto::public_key K_return;
+    crypto::secret_key_to_public_key(k_return, K_return);
+
+    // the return tx that pays us back
+    const crypto::key_image return_ki = rct::rct2ki(rct::pkGen());
+    const input_context_t return_input_context = make_carrot_input_context(return_ki);
+
+    // sender-side ephemeral material over our change address, fixed across the search
+    const janus_anchor_t anchor = gen_janus_anchor();
+    crypto::secret_key d_e;
+    make_carrot_enote_ephemeral_privkey(anchor, return_input_context, K_change, null_payment_id, d_e);
+    mx25519_pubkey D_e;
+    make_carrot_enote_ephemeral_pubkey(d_e, K_change, /*is_subaddress=*/false, D_e);
+    mx25519_pubkey s_unctx;
+    ASSERT_TRUE(make_carrot_uncontextualized_shared_key_sender(d_e, K_return, s_unctx));
+    crypto::hash s_sr;
+    make_carrot_sender_receiver_secret(s_unctx.data, D_e, return_input_context, s_sr);
+
+    // find a K_r where the return view tag equals our internal nominal tag (real 24-bit collision).
+    // K_r must stay a valid curve point so the internal scan's curve ops don't fault, so we step
+    // by a fixed point rather than incrementing raw bytes; only cheap hashes gate the match.
+    rct::key Kr_acc = rct::pkGen();
+    const rct::key Kr_step = rct::pkGen();
+    crypto::public_key K_r{};
+    view_tag_t collided_vt{};
+    bool found = false;
+    for (std::uint64_t i = 0; i < (1ull << 28); ++i)
+    {
+        K_r = rct::rct2pk(Kr_acc);
+        view_tag_t return_vt, internal_vt;
+        make_carrot_view_tag(s_unctx.data, return_input_context, K_r, return_vt);
+        recipient.s_view_balance_dev.make_internal_view_tag(return_input_context, K_r, internal_vt);
+        if (std::memcmp(return_vt.bytes, internal_vt.bytes, VIEW_TAG_BYTES) == 0)
+        {
+            collided_vt = return_vt;
+            found = true;
+            break;
+        }
+        Kr_acc = rct::addKeys(Kr_acc, Kr_step);
+    }
+    ASSERT_TRUE(found) << "no view-tag collision found within search budget";
+
+    // build the valid return enote at the collided K_r
+    const rct::xmr_amount amount = 1337;
+    crypto::secret_key k_a;
+    make_carrot_amount_blinding_factor(s_sr, amount, K_change, carrot::CarrotEnoteType::PAYMENT, k_a);
+
+    carrot::CarrotEnoteV1 enote{};
+    enote.onetime_address = K_r;
+    enote.amount_commitment = rct::commit(amount, rct::sk2rct(k_a));
+    enote.amount_enc = encrypt_carrot_amount(amount, s_sr, K_r);
+    enote.anchor_enc = encrypt_carrot_anchor(anchor, s_sr, K_r);
+    enote.view_tag = collided_vt;
+    enote.enote_ephemeral_pubkey = D_e;
+    enote.tx_first_key_image = return_ki;
+    enote.asset_type = "SAL1";
+
+    // register the return output as the change scan would have
+    recipient.insert_return_output_info({{K_r, carrot::return_output_info_t(
+        origin_input_context, K_o, K_change, K_change,
+        crypto::key_image{}, crypto::secret_key{}, crypto::secret_key{})}});
+
+    // the collision really does make the internal nominal tag match the enote's tag
+    view_tag_t internal_vt_check;
+    recipient.s_view_balance_dev.make_internal_view_tag(return_input_context, K_r, internal_vt_check);
+    ASSERT_EQ(0, std::memcmp(internal_vt_check.bytes, enote.view_tag.bytes, VIEW_TAG_BYTES));
+
+    // must still be detected as a return despite the collision
+    crypto::secret_key ext_g, ext_t, abf;
+    crypto::public_key spend_pubkey, return_address;
+    rct::xmr_amount scanned_amount = 0;
+    carrot::CarrotEnoteType etype;
+    janus_anchor_t internal_msg;
+    bool is_return = false;
+    const bool r = carrot::try_scan_carrot_enote_internal_receiver(enote, recipient,
+        ext_g, ext_t, spend_pubkey, scanned_amount, abf, etype, internal_msg,
+        return_address, is_return);
+
+    ASSERT_TRUE(r) << "return output dropped on view-tag collision (F6)";
+    EXPECT_TRUE(is_return);
+    EXPECT_EQ(amount, scanned_amount);
+    EXPECT_EQ(K_change, spend_pubkey);
+    EXPECT_EQ(K_r, return_address);
 }

--- a/tests/unit_tests/json_serialization.cpp
+++ b/tests/unit_tests/json_serialization.cpp
@@ -21,7 +21,8 @@ namespace test
     make_miner_transaction(cryptonote::account_public_address const& to)
     {
         cryptonote::transaction tx{};
-        if (!cryptonote::construct_miner_tx(0, 0, 5000, 500, 500, to, tx))
+        crypto::public_key miner_tx_key{};
+        if (!cryptonote::construct_miner_tx(0, 0, 5000, 500, 500, to, miner_tx_key, tx))
             throw std::runtime_error{"miner transaction construction error"};
 
         crypto::hash id{0};

--- a/tests/unit_tests/test_tx_utils.cpp
+++ b/tests/unit_tests/test_tx_utils.cpp
@@ -141,7 +141,8 @@ TEST(parse_and_validate_tx_extra, is_valid_tx_extra_parsed)
   cryptonote::account_base acc;
   acc.generate();
   cryptonote::blobdata b = "dsdsdfsdfsf";
-  ASSERT_TRUE(cryptonote::construct_miner_tx(0, 0, 10000000000000, 1000, TEST_FEE, acc.get_keys().m_account_address, tx, cryptonote::network_type::FAKECHAIN, {}, b, 1));
+  crypto::public_key miner_tx_key{};
+  ASSERT_TRUE(cryptonote::construct_miner_tx(0, 0, 10000000000000, 1000, TEST_FEE, acc.get_keys().m_account_address, miner_tx_key, tx, cryptonote::network_type::FAKECHAIN, {}, b, 1));
   crypto::public_key tx_pub_key = cryptonote::get_tx_pub_key_from_extra(tx);
   ASSERT_NE(tx_pub_key, crypto::null_pkey);
 }
@@ -151,7 +152,8 @@ TEST(parse_and_validate_tx_extra, fails_on_big_extra_nonce)
   cryptonote::account_base acc;
   acc.generate();
   cryptonote::blobdata b(TX_EXTRA_NONCE_MAX_COUNT + 1, 0);
-  ASSERT_FALSE(cryptonote::construct_miner_tx(0, 0, 10000000000000, 1000, TEST_FEE, acc.get_keys().m_account_address, tx, cryptonote::network_type::FAKECHAIN, {}, b, 1));
+  crypto::public_key miner_tx_key{};
+  ASSERT_FALSE(cryptonote::construct_miner_tx(0, 0, 10000000000000, 1000, TEST_FEE, acc.get_keys().m_account_address, miner_tx_key, tx, cryptonote::network_type::FAKECHAIN, {}, b, 1));
 }
 TEST(parse_and_validate_tx_extra, fails_on_wrong_size_in_extra_nonce)
 {


### PR DESCRIPTION
I've been holding and following Salvium for a while now, and I wanted to actually give something back instead of just watching from the sidelines. The return address and return payment side of the protocol is one of the things that pulled me in, so that's where I started reading.

## What I found

Going through the carrot scanning code, `try_scan_carrot_enote_internal_receiver` stood out to me. It uses the internal nominal view tag as a quick filter for change outputs. On a match it runs the internal scan, and if that scan fails it returns straight away, before it ever reaches the return output map lookup further down in the same function.

The problem is that the view tag is only 3 bytes. It is a probabilistic filter, not proof of anything. So when a real return output's view tag happens to line up with the recipient's internal nominal tag, which is roughly 1 in 2^24, scanning walks into the change branch, fails it, and bails out. The return output never gets checked against the return map, so it is never detected. And because the tag is deterministic for a given output, a rescan lands on the exact same miss every time. The coins are on chain and still yours, but the wallet cannot see them.

It is rare, but it is silent and permanent when it hits, and it lands on the one feature that makes Salvium what it is. So it felt worth fixing.

```
 before:  a failed internal scan returns early, return map is never reached

       incoming enote
             |
             v
      nominal vt == enote vt ?
        |              |
     no |              | yes (real match, or ~1 in 2^24 collision)
        |              v
        |        internal scan (is it change?)
        |          |              |
        |      ok  |              | fail
        |          v              v
        |     record &        return false        <-- return output dropped,
        |     return true     (return map skipped)     funds invisible
        v
      in return map ?
        |          |
     no |          | yes
        v          v
     return     scan return output  ->  detected
     false
```

The change itself is small. Nest the change handling under a successful internal scan, and let a failed scan fall through to the return map lookup that is already there. Nothing changes when the tags do not collide.

```
 after:   a failed internal scan falls through to the return map

       incoming enote
             |
             v
      nominal vt == enote vt ?
        |              |
     no |              | yes
        |              v
        |        internal scan (is it change?)
        |          |              |
        |      ok  |              | fail
        |          v              |
        |     record &            | fall through
        |     return true         |
        |     (done)              |
        |                         |
        +------------+------------+
                     |
                     v
              in return map ?
                |          |
             no |          | yes
                v          v
             return     scan return output  ->  detected
             false
```

While I was in there I also removed the `HERE BE DRAGONS` placeholder line and fixed two error strings that say "coinbase" but actually describe return enotes.

## A second one, on the way

Reading the tx build side, `finalize_all_proofs_from_transfer_details` takes `change_index` from `get_output_enote_proposals` and uses it to index the output list and derive the change opening. But `get_output_enote_proposals` only writes that index when there is a CHANGE type self-send, so a proposal without one leaves it uninitialized. I initialized it to a sentinel and made the wallet throw a clear error instead of reading an uninitialized index.

## How I tested it

I wanted to prove the first one rather than just argue it, so I added two tests in `carrot_return_index.cpp`.

`return_output_detected` builds a valid return output and checks it gets recovered with the right amount, type and address. It runs in milliseconds.

`DISABLED_view_tag_collision_return_still_detected` brute forces a real 24-bit collision, then checks the return is still found. It fails on current master, where the return is dropped, and passes with this change. I left it disabled because the search takes a few minutes.

## Reproducing it

```
cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON
cmake --build build --target unit_tests -j

# fast check, milliseconds
./build/tests/unit_tests/unit_tests --gtest_filter='carrot_return_index.return_output_detected'

# the collision proof, a few minutes
./build/tests/unit_tests/unit_tests --gtest_also_run_disabled_tests \
    --gtest_filter='carrot_return_index.DISABLED_view_tag_collision_return_still_detected'
```

To see the bug itself, revert the `scan.cpp` change (put back the early `return false` on a failed internal scan) and run the disabled test again. It fails with `return output dropped on view-tag collision`. With the change in place it passes.

## Notes

The functions here, `try_scan_carrot_enote_internal_receiver`, `scan_return_output`, and the return map, are Salvium specific. The return payment feature does not exist in upstream Carrot, so this is not an inherited bug.

CI here only does release builds, so it does not build or run `unit_tests`; these tests are for local verification. The target also does not currently compile on main, because `json_serialization.cpp` and `test_tx_utils.cpp` call `construct_miner_tx` with the old signature. I included that small fix so the suite builds and these tests can actually be run. `net.cpp` also fails against Boost 1.85 and newer (it uses `expires_from_now` and `io_context::work`, both removed in 1.85); I left that alone since it is a separate, toolchain dependent change. Happy to pull the build fix into its own PR if you would rather keep this one to the scan change.

That internal and return branch did not really have coverage either. The existing scan helper drives it with a default constructed account, which can never match, so the path was effectively untested. That is probably how this sat unnoticed for so long. The fast test exercises it directly.

Happy to adjust naming, split the commits, or rework anything to fit how you would prefer it. Glad to help where I can.
