### PR TITLE
Fix: Patch 9 security and correctness bugs found in code audit

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -35,6 +35,7 @@
 
 #include <memory>  // std::unique_ptr
 #include <cstring>  // memcpy
+#include <thread>  // std::this_thread::yield
 
 #ifdef WIN32
 #include <winioctl.h>
@@ -158,8 +159,9 @@ int BlockchainLMDB::compare_uint64(const MDB_val *a, const MDB_val *b)
 
 int BlockchainLMDB::compare_hash32(const MDB_val *a, const MDB_val *b)
 {
-  uint32_t *va = (uint32_t*) a->mv_data;
-  uint32_t *vb = (uint32_t*) b->mv_data;
+  uint32_t va[8], vb[8];
+  memcpy(va, a->mv_data, 32);
+  memcpy(vb, b->mv_data, 32);
   for (int n = 7; n >= 0; n--)
   {
     if (va[n] == vb[n])
@@ -522,7 +524,8 @@ void mdb_txn_safe::prevent_new_txns()
 
 void mdb_txn_safe::wait_no_active_txns()
 {
-  while (num_active_txns > 0);
+  while (num_active_txns > 0)
+    std::this_thread::yield();
 }
 
 void mdb_txn_safe::allow_new_txns()

--- a/src/carrot_core/sparc.cpp
+++ b/src/carrot_core/sparc.cpp
@@ -92,7 +92,7 @@ namespace carrot {
     
     // Step 3: Calculate the challenge scalar
     std::vector<rct::key> keys{commitment, K_o};
-    rct::key challenge = rct::hash_to_scalar(keys); // c = H(R || K_o)
+    rct::key challenge = carrot::hash_to_scalar(keys); // c = H(R || K_o || domain_separator)
     
     // Step 4: Calculate responses
     rct::key response_x;
@@ -118,7 +118,7 @@ namespace carrot {
     
     // Step 1: calculate the challenge
     std::vector<rct::key> keys{proof.R, K_o};
-    rct::key recomputed_challenge = rct::hash_to_scalar(keys);
+    rct::key recomputed_challenge = carrot::hash_to_scalar(keys);
     
     // Step 2: Calculate z_xG + x_yT
     rct::key z_xG  = rct::scalarmultBase(proof.z1); // z1 * G

--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -203,6 +203,7 @@ namespace crypto {
    */
   template<typename T>
   typename std::enable_if<std::is_unsigned<T>::value, T>::type rand_idx(T sz) {
+    if (sz == 0) return 0;
     return crypto::rand_range<T>(0, sz-1);
   }
 

--- a/src/cryptonote_basic/difficulty.cpp
+++ b/src/cryptonote_basic/difficulty.cpp
@@ -271,7 +271,7 @@ namespace cryptonote {
     // adjust=0.99 for 90 < N < 130
     const long double adjust = 0.998;
     // The divisor k normalizes LWMA.
-    const long double k = N * (N + 1) / 2;
+    const long double k = static_cast<long double>(N) * static_cast<long double>(N + 1) / 2.0L;
 
     long double LWMA(0), sum_inverse_D(0), harmonic_mean_D(0), nextDifficulty(0);
     int64_t solveTime(0);

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -474,7 +474,7 @@ namespace config
       "KWv3Vo1/Gny+1vfaxsXhBQiG1KlHkafNGarzoL0WHW4ocqaaqF5iv8i35A==\n"
       "-----END PUBLIC KEY-----\n";
 
-    std::string const TREASURY_ADDRESS_CARROT = ""; // TODO: generate stagenet Carrot treasury address ?
+    std::string const TREASURY_ADDRESS_CARROT = "fuLMowH85abK8nz9BBMEem7MAfUbQu4aSHHUV9j5Z86o6Go9Lv2U5ZQiJCWPY9R9HA8p5idburazjAhCqDngLo7fYPCD9ciM9ee1A";
     std::string const TREASURY_ADDRESS = "fuLMowH85abK8nz9BBMEem7MAfUbQu4aSHHUV9j5Z86o6Go9Lv2U5ZQiJCWPY9R9HA8p5idburazjAhCqDngLo7fYPCD9ciM9ee1A";
 
     // treasury payout {tx-key, output-key, anchor_enc, view_tag} tuples

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4062,6 +4062,12 @@ bool Blockchain::check_tx_asset_types(const transaction& tx, tx_verification_con
         tvc.m_verifivation_failed = true; 
         return false;
       }
+    } else if (tx.type == cryptonote::transaction_type::RETURN) {
+      if (tx.source_asset_type != "SAL1" || tx.destination_asset_type != "SAL1") {
+        MERROR_VER("Invalid source/dest asset type for RETURN - provided source asset: " << tx.source_asset_type << ", provided destination asset: " << tx.destination_asset_type << ", expected SAL1 for both");
+        tvc.m_verifivation_failed = true;
+        return false;
+      }
     } else if (tx.type == cryptonote::transaction_type::TRANSFER) {
       if (tx.source_asset_type != tx.destination_asset_type) {
         MERROR_VER("Mismatched asset types for TRANSFER - provided source asset: " << tx.source_asset_type << ", provided destination asset: " << tx.destination_asset_type << ", expected them to match");
@@ -4159,21 +4165,21 @@ bool Blockchain::check_tx_type_and_version(const transaction& tx, tx_verificatio
     }
   }
 
-  // Reverse the order of checking now, because we're using >=
   if (hf_version >= HF_VERSION_ENABLE_TOKENS) {
     if (tx.type == cryptonote::transaction_type::TRANSFER ||
         tx.type == cryptonote::transaction_type::RETURN ||
         tx.type == cryptonote::transaction_type::ROLLUP ||
         tx.type == cryptonote::transaction_type::CREATE_TOKEN) {
       if (tx.version < TRANSACTION_VERSION_ENABLE_TOKENS) {
+        MERROR("Transaction version " << std::to_string(tx.version) << " is too low for TRANSFER/RETURN/ROLLUP/CREATE_TOKEN at HF_ENABLE_TOKENS, expected " << std::to_string(TRANSACTION_VERSION_ENABLE_TOKENS));
+        tvc.m_version_mismatch = true;
+        return false;
       }
     } else {
       if (tx.version != TRANSACTION_VERSION_ENABLE_TOKENS) {
-      }
-      if (tx.type == cryptonote::transaction_type::PROTOCOL) {
-        // Allowed multiple asset_types for `vout` entries 
-      } else {
-        // No mixing of asset_types permitted - verify here
+        MERROR("Transaction version " << std::to_string(tx.version) << " is not supported for tx type " << tx.type << " at HF_ENABLE_TOKENS, expected " << std::to_string(TRANSACTION_VERSION_ENABLE_TOKENS));
+        tvc.m_version_mismatch = true;
+        return false;
       }
     }
   }
@@ -4301,7 +4307,7 @@ bool Blockchain::have_tx_keyimges_as_spent(const transaction &tx) const
 bool Blockchain::expand_transaction_2(transaction &tx, const crypto::hash &tx_prefix_hash, const std::vector<std::vector<rct::ctkey>> &pubkeys, const uint8_t &hf_version)
 {
   PERF_TIMER(expand_transaction_2);
-  CHECK_AND_ASSERT_MES(tx.version == 2 || tx.version == 3 || tx.version == 4 || tx.version == 5, false, "Transaction version is not 2/3/5");
+  CHECK_AND_ASSERT_MES(tx.version == 2 || tx.version == 3 || tx.version == 4 || tx.version == 5, false, "Transaction version is not 2/3/4/5");
 
   rct::rctSig &rv = tx.rct_signatures;
 


### PR DESCRIPTION
This commit fixes the following issues discovered during a thorough source code audit of the Salvium codebase:

1. HF11 transaction version checks were empty branches (no-op). Added proper validation with error messages and rejection.

2. rand_idx() would wrap to UINT64_MAX if called with size 0, causing out-of-bounds reads. Added a zero-size guard.

3. Stagenet treasury address was an empty string. Set it to the mainnet treasury address to prevent consensus failures on stagenet.

4. SPARC zero-knowledge proofs used rct::hash_to_scalar without domain separation, enabling cross-protocol challenge collisions. Switched to the domain-separated carrot::hash_to_scalar instead.

5. Difficulty V2 LWMA calculation could overflow N*(N+1) before converting to floating point. Cast to long double before multiplication.

6. RETURN transaction type was not handled in the HF11 asset type validation check, causing valid RETURN txs to be rejected. Added proper validation.

7. compare_hash32() used a direct uint32_t* cast from LMDB data, causing unaligned access crashes on ARM. Replaced with memcpy.

8. wait_no_active_txns() was a tight spinlock burning 100% CPU with no backoff. Added std::this_thread::yield().

9. Error message said 'Transaction version is not 2/3/5' but the code actually checks for versions 2, 3, 4, and 5. Fixed the message.