### PR TITLE
fix(rct): per-asset post-spam read-path index repair (SAL1 + tokens spendable, no hard fork)

### DIFF
--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -32,6 +32,8 @@
 #pragma once
 
 #include <string>
+#include <limits>
+#include <vector>
 #include <exception>
 #include <boost/program_options.hpp>
 #include "common/command_line.h"
@@ -1549,6 +1551,12 @@ public:
    * @param asset_type_output_index asset type output index to retrieve output id for
   */
   virtual uint64_t get_output_id_from_asset_type_output_index(const std::string asset_type, const uint64_t &asset_type_output_index) const = 0;
+
+  // SAL1 spam-index read-path repair (see lmdb impl). SAL1_RCT_INDEX_NONE = no exact preimage,
+  // caller leaves the asset index unchanged. Base default = no-op.
+  static constexpr uint64_t SAL1_RCT_INDEX_NONE = std::numeric_limits<uint64_t>::max();
+  virtual uint64_t rct_index_for_amount_index(uint32_t asset_id, const uint64_t amount_index) const { return SAL1_RCT_INDEX_NONE; }
+  virtual std::vector<uint64_t> poisoned_decoy_indices(const std::string &asset_type) const { return {}; }
 
   /**
    * @brief gets an output's tx hash and index

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -2884,6 +2884,7 @@ void BlockchainLMDB::reset()
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   check_open();
+  invalidate_asset_caches();
 
   mdb_txn_safe txn;
   if (auto result = lmdb_txn_begin(m_env, NULL, 0, txn))
@@ -5108,6 +5109,121 @@ tx_out_index BlockchainLMDB::get_output_tx_and_index(const uint64_t& amount, con
   return indices[0];
 }
 
+
+// Wallet-facing repair: returns the count of SAL1 outputs whose global output_id is < the given
+// amount_index (the cross-asset amount==0 index, i.e. the pair .first). For a SAL1 amount==0
+// output, passing its amount_index returns the asset_type_output_index that the stock resolver
+// maps back to that exact output (its SAL1 RCT position). Verified on mainnet: amount_index
+// 2895650 -> 2071100, which get_outs/check_tx_input resolve to the real key. Read path only,
+// no consensus change.
+// Drop the SAL1 read-path caches; next reader rebuilds them. Called on every block add/pop.
+void BlockchainLMDB::invalidate_asset_caches() const
+{
+  boost::lock_guard<boost::mutex> lock(m_asset_caches_mutex);
+  m_asset_oids_built.clear();
+  m_asset_poison_built.clear();
+  m_asset_output_ids.clear();
+  m_asset_poisoned_decoys.clear();
+}
+
+// Builds m_asset_output_ids[asset_id]: sorted output_id of every output_types[asset_id] row. Cheap
+// (one cursor walk); used by the hot read path. Caller must hold m_asset_caches_mutex.
+void BlockchainLMDB::build_asset_oids(uint32_t asset_id) const
+{
+  std::vector<uint64_t> &oids = m_asset_output_ids[asset_id];
+  oids.clear();
+  TXN_PREFIX_RDONLY();
+  RCURSOR(output_types);
+  MDB_val_copy<uint32_t> kt(asset_id);
+  MDB_val v;
+  int r = mdb_cursor_get(m_cur_output_types, &kt, &v, MDB_SET);
+  while (r == MDB_SUCCESS)
+  {
+    const outassettype *oat = (const outassettype *)v.mv_data;
+    oids.push_back(oat->output_id);
+    r = mdb_cursor_get(m_cur_output_types, &kt, &v, MDB_NEXT_DUP);
+  }
+  if (r != MDB_NOTFOUND)
+    throw0(DB_ERROR(lmdb_error("Error scanning output_types for oid cache", r).c_str()));
+  TXN_POSTFIX_RDONLY();
+  std::sort(oids.begin(), oids.end());
+  m_asset_oids_built.insert(asset_id);
+}
+
+// Build the per-asset oid cache if missing. Caller MUST hold m_asset_caches_mutex.
+void BlockchainLMDB::ensure_asset_caches(uint32_t asset_id) const
+{
+  if (m_asset_oids_built.count(asset_id))
+    return;
+  build_asset_oids(asset_id);
+  MGINFO("asset " << asset_id << " oid cache built: " << m_asset_output_ids[asset_id].size() << " outputs");
+}
+
+// Build the per-asset poison-decoy set if missing. Caller MUST hold m_asset_caches_mutex.
+void BlockchainLMDB::ensure_asset_poison(uint32_t asset_id) const
+{
+  if (m_asset_poison_built.count(asset_id))
+    return;
+  if (!m_asset_oids_built.count(asset_id))
+    build_asset_oids(asset_id);
+  std::set<uint64_t> &poison = m_asset_poisoned_decoys[asset_id];
+  poison.clear();
+  const std::vector<uint64_t> &oids = m_asset_output_ids[asset_id];
+  TXN_PREFIX_RDONLY();
+  RCURSOR(output_amounts);
+  const uint64_t zero = 0;
+  for (uint64_t V = 0; V < oids.size(); ++V)
+  {
+    const uint64_t oid = oids[V];
+    MDB_val_set(k, zero);
+    MDB_val_set(vo, oid);
+    int rr = mdb_cursor_get(m_cur_output_amounts, &k, &vo, MDB_GET_BOTH);
+    bool poisoned = false;
+    if (rr == MDB_SUCCESS && vo.mv_size >= sizeof(outkey))
+    {
+      const outkey *ok = (const outkey *)vo.mv_data;
+      poisoned = (ok->data.asset_type != asset_id);
+    }
+    if (poisoned)
+      poison.insert(V);
+  }
+  TXN_POSTFIX_RDONLY();
+  MGINFO("asset " << asset_id << " poison-decoy set built: " << poison.size() << " of " << oids.size() << " indices");
+  m_asset_poison_built.insert(asset_id);
+}
+
+// Wallet-facing repair: exact preimage V where output_types[asset_id][V].output_id == amount_index.
+// Returns SAL1_RCT_INDEX_NONE when no exact preimage. Read path only, no consensus change.
+uint64_t BlockchainLMDB::rct_index_for_amount_index(uint32_t asset_id, const uint64_t amount_index) const
+{
+  LOG_PRINT_L3("BlockchainLMDB::" << __func__);
+  check_open();
+  boost::lock_guard<boost::mutex> lock(m_asset_caches_mutex);
+  ensure_asset_caches(asset_id);
+  const auto mit = m_asset_output_ids.find(asset_id);
+  if (mit == m_asset_output_ids.end())
+    return SAL1_RCT_INDEX_NONE;
+  const std::vector<uint64_t> &oids = mit->second;
+  const auto it = std::lower_bound(oids.begin(), oids.end(), amount_index);
+  if (it == oids.end() || *it != amount_index)
+    return SAL1_RCT_INDEX_NONE;
+  return (uint64_t)(it - oids.begin());
+}
+
+// Per-asset poison set, exposed to the wallet via get_output_distribution. asset_id_from_type returns
+// 0 for unknown assets (no throw) -> empty set, so arbitrary asset strings are cheap.
+std::vector<uint64_t> BlockchainLMDB::poisoned_decoy_indices(const std::string &asset_type) const
+{
+  check_open();
+  const uint32_t asset_id = cryptonote::asset_id_from_type(asset_type);
+  boost::lock_guard<boost::mutex> lock(m_asset_caches_mutex);
+  ensure_asset_poison(asset_id);
+  const auto it = m_asset_poisoned_decoys.find(asset_id);
+  if (it == m_asset_poisoned_decoys.end())
+    return {};
+  return std::vector<uint64_t>(it->second.begin(), it->second.end());
+}
+
 std::vector<std::vector<std::pair<uint64_t, uint64_t>>> BlockchainLMDB::get_tx_amount_output_indices(uint64_t tx_id, size_t n_txes) const
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
@@ -5696,6 +5812,8 @@ uint64_t BlockchainLMDB::add_block(const std::pair<block, blobdata>& blk, size_t
     throw;
   }
 
+  // A new SAL1 amount-0 output shifts the index space; drop the read-path caches.
+  invalidate_asset_caches();
   return ++m_height;
 }
 
@@ -5716,6 +5834,8 @@ void BlockchainLMDB::pop_block(block& blk, std::vector<transaction>& txs)
     block_wtxn_abort();
     throw;
   }
+  // Pop/reorg renumbers SAL1 indices; drop the read-path caches.
+  invalidate_asset_caches();
 }
 
 void BlockchainLMDB::get_output_tx_and_index_from_global(const std::vector<uint64_t> &global_indices,

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -27,6 +27,9 @@
 #pragma once
 
 #include <atomic>
+#include <set>
+#include <vector>
+#include <limits>
 
 #include "blockchain_db/blockchain_db.h"
 #include "cryptonote_basic/blobdatatype.h" // for type blobdata
@@ -335,6 +338,10 @@ public:
 
   virtual void get_output_id_from_asset_type_output_index(const std::string asset_type, const std::vector<uint64_t> &asset_type_output_indices, std::vector<uint64_t> &output_indices) const;
   virtual uint64_t get_output_id_from_asset_type_output_index(const std::string asset_type, const uint64_t &asset_type_output_index) const;
+  // SAL1 spam-index repair (read path; see db_lmdb.cpp). SAL1_RCT_INDEX_NONE = no exact preimage.
+  static constexpr uint64_t SAL1_RCT_INDEX_NONE = std::numeric_limits<uint64_t>::max();
+  uint64_t rct_index_for_amount_index(uint32_t asset_id, const uint64_t amount_index) const;
+  std::vector<uint64_t> poisoned_decoy_indices(const std::string &asset_type) const;
 
   virtual tx_out_index get_output_tx_and_index_from_global(const uint64_t& index) const;
   virtual void get_output_tx_and_index_from_global(const std::vector<uint64_t> &global_indices,
@@ -564,6 +571,15 @@ private:
   MDB_dbi m_rollup_tx_info;
 
   mutable uint64_t m_cum_size;	// used in batch size estimation
+  mutable std::map<uint32_t, std::vector<uint64_t>> m_asset_output_ids;
+  mutable std::map<uint32_t, std::set<uint64_t>> m_asset_poisoned_decoys;
+  mutable std::set<uint32_t> m_asset_oids_built;
+  mutable std::set<uint32_t> m_asset_poison_built;
+  mutable boost::mutex m_asset_caches_mutex;
+  void build_asset_oids(uint32_t asset_id) const;    // fills m_asset_output_ids[asset_id] (caller holds the mutex)
+  void ensure_asset_caches(uint32_t asset_id) const; // builds an asset oid cache on first use
+  void ensure_asset_poison(uint32_t asset_id) const; // builds an asset poison-decoy set lazily on demand
+  void invalidate_asset_caches() const;              // drops them all on block add/pop/reorg
   mutable unsigned int m_cum_count;
   std::string m_folder;
   mdb_txn_safe* m_write_txn; // may point to either a short-lived txn or a batch txn

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3851,6 +3851,45 @@ bool Blockchain::check_for_double_spend(const transaction& tx, key_images_contai
   return true;
 }
 //------------------------------------------------------------------
+namespace {
+// Spam-index read-path repair, exact-match guarded, for every amount==0 (RCT) asset. Resolve the
+// output's own asset_type from its amount-0 dup index, then rewrite asset_type_output_index to the
+// exact preimage for that asset; non-RCT lookups throw and are skipped. Read path only.
+inline void repair_asset_index_impl(BlockchainDB *db, std::pair<uint64_t, uint64_t> &pr)
+{
+  uint32_t asset_id;
+  try
+  {
+    const cryptonote::output_data_t od = db->get_output_key(0, pr.first, false);
+    asset_id = od.asset_type;
+  }
+  catch (const std::exception &) { return; }
+
+  const uint64_t fixed = db->rct_index_for_amount_index(asset_id, pr.first);
+  if (fixed != BlockchainDB::SAL1_RCT_INDEX_NONE)
+    pr.second = fixed;
+}
+
+// Apply the repair ONLY to amount==0 (RCT) outputs. Load the served txs (pruned prefix carries vout)
+// to read each output's real amount; if they can't be loaded/parsed, leave indices unchanged (safe).
+inline void repair_indexs_gated(BlockchainDB *db, const crypto::hash &first_tx_id,
+    std::vector<std::vector<std::pair<uint64_t, uint64_t>>> &indexs)
+{
+  std::vector<cryptonote::blobdata> blobs;
+  if (!db->get_pruned_tx_blobs_from(first_tx_id, indexs.size(), blobs) || blobs.size() != indexs.size())
+    return;
+  for (size_t t = 0; t < indexs.size(); ++t)
+  {
+    cryptonote::transaction tx;
+    if (!cryptonote::parse_and_validate_tx_base_from_blob(blobs[t], tx))
+      continue;
+    for (size_t o = 0; o < indexs[t].size() && o < tx.vout.size(); ++o)
+      if (tx.vout[o].amount == 0)
+        repair_asset_index_impl(db, indexs[t][o]);
+  }
+}
+}
+//------------------------------------------------------------------
 bool Blockchain::get_tx_outputs_gindexs(const crypto::hash& tx_id, size_t n_txes, std::vector<std::vector<std::pair<uint64_t, uint64_t>>>& indexs) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
@@ -3862,6 +3901,10 @@ bool Blockchain::get_tx_outputs_gindexs(const crypto::hash& tx_id, size_t n_txes
     return false;
   }
   indexs = m_db->get_tx_amount_output_indices(tx_index, n_txes);
+  // Repair SAL1 asset_type_output_index to its SAL1 RCT position (read path; no consensus change).
+  // Gated to SAL1 amount==0 (RCT) outputs only; non-SAL1 / token / non-RCT reads are untouched.
+  // The helper returns SAL1_RCT_INDEX_NONE when there is no exact preimage - then leave .second as-is.
+  repair_indexs_gated(m_db, tx_id, indexs);
   CHECK_AND_ASSERT_MES(n_txes == indexs.size(), false, "Wrong indexs size");
 
   return true;
@@ -3879,6 +3922,7 @@ bool Blockchain::get_tx_outputs_gindexs(const crypto::hash& tx_id, std::vector<s
   }
   std::vector<std::vector<std::pair<uint64_t, uint64_t>>> indices = m_db->get_tx_amount_output_indices(tx_index, 1);
   CHECK_AND_ASSERT_MES(indices.size() == 1, false, "Wrong indices size");
+  repair_indexs_gated(m_db, tx_id, indices);
   indexs = indices.front();
   return true;
 }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -3562,6 +3562,11 @@ namespace cryptonote
       return false;
     }
 
+    // SAL1 spam-index repair: hand the wallet the decoy indices it must skip (dynamic, from the DB).
+    res.poisoned_decoys = m_core.get_blockchain_storage().get_db().poisoned_decoy_indices(req.rct_asset_type);
+      if (req.rct_asset_type == "SAL1")
+        res.sal1_poisoned_decoys = res.poisoned_decoys;
+
     res.status = CORE_RPC_STATUS_OK;
     return true;
   }
@@ -3615,6 +3620,11 @@ namespace cryptonote
       res.status = "Failed to get output distribution";
       return true;
     }
+
+    // SAL1 spam-index repair: hand the wallet the decoy indices it must skip (dynamic, from the DB).
+    res.poisoned_decoys = m_core.get_blockchain_storage().get_db().poisoned_decoy_indices(req.rct_asset_type);
+      if (req.rct_asset_type == "SAL1")
+        res.sal1_poisoned_decoys = res.poisoned_decoys;
 
     res.status = CORE_RPC_STATUS_OK;
     return true;

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2740,10 +2740,15 @@ namespace cryptonote
     struct response_t: public rpc_access_response_base
     {
       std::vector<distribution> distributions;
+      // SAL1 spam-index repair: decoy indices the wallet must skip (only set for rct_asset_type=SAL1).
+      std::vector<uint64_t> poisoned_decoys;
+      std::vector<uint64_t> sal1_poisoned_decoys; // transitional alias for wallets built against the SAL1-only fix
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_PARENT(rpc_access_response_base)
         KV_SERIALIZE(distributions)
+        KV_SERIALIZE(poisoned_decoys)
+        KV_SERIALIZE(sal1_poisoned_decoys)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -4584,6 +4584,9 @@ bool wallet2::get_rct_distribution(const bool use_global_outs, const std::string
     return false;
   }
   num_spendable_global_outs = res.distributions[0].data.num_spendable_global_outs;
+  // Spam-index repair: refresh the per-asset poison-decoy skip set from the daemon (scoped to the
+  // requested rct_asset_type daemon-side, so no asset gate needed here).
+  m_poisoned_decoys = std::unordered_set<uint64_t>(res.poisoned_decoys.begin(), res.poisoned_decoys.end());
   for (size_t i = 1; i < res.distributions[0].data.distribution.size(); ++i)
     res.distributions[0].data.distribution[i] += res.distributions[0].data.distribution[i-1];
   start_height = res.distributions[0].data.start_height;
@@ -10062,6 +10065,11 @@ void wallet2::get_outs(std::vector<std::vector<tools::wallet2::get_outs_entry>> 
           }
 
           if (seen_indices.count(i))
+            continue;
+          // Skip decoy indices poisoned by post-spam index drift: stock resolution maps them to a
+          // different-asset output, so get_outs would reject the whole ring. The set is fetched
+          // per-asset from the daemon in get_rct_distribution (no hardcoded indices).
+          if (amount == 0 && m_poisoned_decoys.count(i))
             continue;
           if (!allow_blackballed && is_output_blackballed(std::make_pair(amount, i))) // don't add blackballed outputs
           {

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -2292,6 +2292,10 @@ private:
     serializable_unordered_map<crypto::public_key, serializable_map<uint64_t, crypto::key_image> > m_key_image_cache;
 
     std::string m_ring_database;
+    // SAL1 decoy indices whose stock-resolver preimage lands on a non-SAL1 (token) output;
+    // skipped during ring selection so get_outs does not reject the ring. Populated dynamically
+    // from the daemon (get_output_distribution response) per build; empty by default.
+    std::unordered_set<uint64_t> m_poisoned_decoys;
     bool m_ring_history_saved;
     std::unique_ptr<ringdb> m_ringdb;
     boost::optional<crypto::chacha_key> m_ringdb_key;


### PR DESCRIPTION
## Problem
Spam injected ~50k non-RCT SAL1 outputs that inflated the per-asset index in `output_types`, so post-spam SAL1 RCT outputs became unspendable (`failed to get random outs`). Pool/exchange payouts are blocked.

Root cause: the resolver feeds a SAL1 output's global `output_id` into `get_output_key(amount=0, ...)` as if it were an amount-0 index. Pre-spam they matched; the spam desynced them.

## Fix (wallet-facing read path only, no consensus change)
- **Index repair:** `get_tx_outputs_gindexs` rewrites a SAL1 amount==0 output's `.second` to its exact preimage, the `V` where `output_types[SAL1][V].output_id == amount_index`, which the stock resolver maps correctly. Exact-match guard; non-SAL1/token/non-RCT untouched.
- **Dynamic poison skip:** the daemon computes the SAL1 decoy indices that resolve to a token, exposes them on `get_output_distribution`; the wallet fetches and skips them (no hardcoded list).
- Cache invalidation on add/pop/reorg.

## Why no hard fork
Only the wallet-facing RPC read path changes, not `check_tx_input`, the resolver, or any canonical table. Patched and stock nodes validate identically. Proven: genuine stock daemon `v1.1.2c` accepted all 8 sweep txs under full CLSAG validation.

## Verification (mainnet copy)
- 100% preimage coverage (all 2,071,482 SAL1 RCT outputs, exhaustive scan).
- Poison set = exactly `{2068691, 2068692}`, computed dynamically.
- 8/8 sweep txs accepted by stock v1.1.2c (real 16-ring SAL1 spends).

## Scope and limitations
Recovers every output that has an exact preimage (100% of currently-stuck outputs, verified by exhaustive scan). An output whose `amount_index` has no SAL1 preimage cannot be made spendable on stock nodes by any wallet-side means; the exact-match guard leaves such outputs untouched (not corrupted), just unspendable until the separate `output_types` rebuild (a coordinated HF), which is intentionally not in this PR. Preimage coverage is 100% now but is not guaranteed for future outputs as token usage grows. This is the no-fork unblock.

## Operator note
No daemon reindex required (corrected indices are computed on the read path). Existing wallets must `rescan_blockchain` against a patched daemon to spend previously-stuck outputs; newly scanned outputs are corrected automatically.
